### PR TITLE
Return `Err` instead of panic on incorrect decryption/encryption

### DIFF
--- a/bench/simple.rs
+++ b/bench/simple.rs
@@ -15,9 +15,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("encrypt 100M", |b| b.iter(|| encrypt(pk, msg).unwrap()));
 
-    c.bench_function("decrypt 100M", |b| {
-        b.iter(|| decrypt(sk, encrypted).unwrap())
-    });
+    c.bench_function("decrypt 100M", |b| b.iter(|| decrypt(sk, encrypted).unwrap()));
 }
 
 criterion_group! {


### PR DESCRIPTION
Current implementation will panic if
- Encrypt message decrypted with another valid key
- Pass message with incorrect length to `encrypt` function
- In any case if `decrypt_aead` or `encrypt_aead` will return `Err`

And it's unacceptable.

This PR changes that behaviour by returning `SecpError::InvalidMessage` instead of panics.
