### PR TITLE
fix crypto-mac missing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/ecies/rs"
 
 [dependencies]
 hkdf = "0.11.0"
-libsecp256k1 = "0.3.5"
+secp256k1 = { package = "libsecp256k1", version = "0.6" }
 sha2 = "0.9.2"
 
 # openssl aes


### PR DESCRIPTION
Now crypto-mac  had been yank, update package and rename libsecp256k1 can fix it, 
should use newer rust compiler, higher than nightly-2021-06-17