### PR TITLE
XChaCha20-Poly1305 backend added.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ hkdf = "0.12.3"
 libsecp256k1 = "0.7.1"
 sha2 = "0.10.6"
 
+chacha20poly1305 = {version = "0.10.1", optional=true}
+
 # openssl aes
 openssl = {version = "0.10.42", optional = true}
 
@@ -40,6 +42,7 @@ rand = {version = "0.8.5"}
 
 [features]
 default = ["openssl"]
+stream = ["chacha20poly1305"]
 pure = ["aes-gcm", "typenum"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Elliptic Curve Integrated Encryption Scheme for secp256k1 in Rust, based on [pure Rust implementation](https://github.com/paritytech/libsecp256k1) of secp256k1.
 
-ECIES functionalities are built upon AES-GCM-256 and HKDF-SHA256.
+ECIES functionalities are built upon (AES-GCM-256 and HKDF-SHA256) and XChaCha20-Poly1305.
 
 This is the Rust version of [eciespy](https://github.com/ecies/py).
 
@@ -54,6 +54,14 @@ RUSTFLAGS="-Ctarget-cpu=sandybridge -Ctarget-feature=+aes,+sse2,+sse4.1,+ssse3"
 
 to speed up AES encryption/decryption. This would be no longer necessary when [`aes-gcm` supports automatic CPU detection](https://github.com/RustCrypto/AEADs/issues/243#issuecomment-738821935).
 
+## Alternative Rust XChaCha20-Poly1305 backend
+
+You can choose to use OpenSSL implementation or [pure Rust implementation](https://github.com/RustCrypto/AEADs) of AES-256-GCM:
+
+```toml
+ecies = {version = "0.2", default-features = false, features = ["stream"]}
+```
+
 ## WASM compatibility
 
 It's also possible to build to the `wasm32-unknown-unknown` target with the pure Rust backend. Check out [this repo](https://github.com/ecies/rs-wasm) for more details.
@@ -75,6 +83,7 @@ All functionalities are mutually checked among [different languages](https://git
 Following dependencies are audited:
 
 - [aes-gcm](https://research.nccgroup.com/2020/02/26/public-report-rustcrypto-aes-gcm-and-chacha20poly1305-implementation-review/)
+- [chacha20-poly1305](https://research.nccgroup.com/2020/02/26/public-report-rustcrypto-aes-gcm-and-chacha20poly1305-implementation-review/)
 - [OpenSSL](https://ostif.org/the-ostif-and-quarkslab-audit-of-openssl-is-complete/)
 
 ## Benchmark

--- a/README.md
+++ b/README.md
@@ -68,9 +68,14 @@ It's also possible to build to the `wasm32-unknown-unknown` target with the pure
 
 ## Security
 
+### Why XChaCha20-Poly1305
+
+XChaCha20-Poly1305 is go to option for symmetric ciphers. It gives infinite amount of reuse of same secret key with random disposable nonce and more resistant to side-channel attacks than AES-GCM-256. 
+
+
 ### Why AES-GCM-256 and HKDF-SHA256
 
-AEAD scheme like AES-GCM-256 should be your first option for symmetric ciphers, with unique IVs in each encryption.
+AEAD scheme like AES-GCM-256 can be your option for symmetric ciphers, with unique IVs in each encryption.
 
 For key derivation functions on shared points between two asymmetric keys, HKDFs are [proven](https://github.com/ecies/py/issues/82) to be more secure than simple hash functions like SHA256.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ to speed up AES encryption/decryption. This would be no longer necessary when [`
 
 ## Alternative Rust XChaCha20-Poly1305 backend
 
-You can choose to use OpenSSL implementation or [pure Rust implementation](https://github.com/RustCrypto/AEADs) of XChaCha20-Poly1305:
+You can choose to use [pure Rust implementation](https://github.com/RustCrypto/AEADs) of XChaCha20-Poly1305:
 
 ```toml
 ecies = {version = "0.2.5", default-features = false, features = ["stream"]}
@@ -70,7 +70,7 @@ It's also possible to build to the `wasm32-unknown-unknown` target with the pure
 
 ### Why XChaCha20-Poly1305
 
-XChaCha20-Poly1305 is go to option for symmetric ciphers. It gives infinite amount of reuse of same secret key with random disposable nonce and more resistant to side-channel attacks than AES-GCM-256. 
+XChaCha20-Poly1305 is an excellent choice for symmetric encryption due to its robust security profile, efficient performance, and resistance to side-channel attacks. Its extended nonce size allows for safe reuse of the same key with different nonces, making it well-suited for systems that require high volumes of secure data transmission
 
 
 ### Why AES-GCM-256 and HKDF-SHA256

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ assert_eq!(
 You can choose to use OpenSSL implementation or [pure Rust implementation](https://github.com/RustCrypto/AEADs) of AES-256-GCM:
 
 ```toml
-ecies = {version = "0.2", default-features = false, features = ["pure"]}
+ecies = {version = "0.2.5", default-features = false, features = ["pure"]}
 ```
 
 Due to some [performance problem](https://github.com/RustCrypto/AEADs/issues/243), OpenSSL is the default backend.
@@ -56,10 +56,10 @@ to speed up AES encryption/decryption. This would be no longer necessary when [`
 
 ## Alternative Rust XChaCha20-Poly1305 backend
 
-You can choose to use OpenSSL implementation or [pure Rust implementation](https://github.com/RustCrypto/AEADs) of AES-256-GCM:
+You can choose to use OpenSSL implementation or [pure Rust implementation](https://github.com/RustCrypto/AEADs) of XChaCha20-Poly1305:
 
 ```toml
-ecies = {version = "0.2", default-features = false, features = ["stream"]}
+ecies = {version = "0.2.5", default-features = false, features = ["stream"]}
 ```
 
 ## WASM compatibility
@@ -143,6 +143,9 @@ Found 1 outliers among 10 measurements (10.00%)
 ```
 
 ## Release Notes
+
+### 0.2.5
+- XChaCha20-Poly1305 backend added
 
 ### 0.2.1 ~ 0.2.4
 

--- a/src/chacha20poly1305.rs
+++ b/src/chacha20poly1305.rs
@@ -1,0 +1,35 @@
+use std::env::args;
+use chacha20poly1305;
+use chacha20poly1305::{AeadCore, AeadInPlace, Key, KeyInit, XChaCha20Poly1305, XNonce};
+use chacha20poly1305::aead::{Aead, OsRng};
+use rand::{Rng, thread_rng};
+use crate::consts::{AES_IV_LENGTH, AES_IV_PLUS_TAG_LENGTH, EMPTY_BYTES, XCHACHA20POLY1305_NONCE_LENGTH};
+
+/// XChaCha20-Poly1305 encryption wrapper
+pub fn symmetric_encrypt(key: &[u8], msg: &[u8]) -> Option<Vec<u8>> {
+    let key = Key::from_slice(key);
+    let aead = XChaCha20Poly1305::new(key);
+    let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+
+    let mut msg = aead.encrypt(&nonce, msg).ok()?;
+    msg.extend(nonce.iter());
+
+    Some(msg)
+}
+
+/// XChaCha20-Poly1305 decryption wrapper
+pub fn symmetric_decrypt(key: &[u8], encrypted_msg: &[u8]) -> Option<Vec<u8>> {
+    if encrypted_msg.len() < XCHACHA20POLY1305_NONCE_LENGTH {
+        return None;
+    }
+
+    let nonce = &encrypted_msg[encrypted_msg.len()-XCHACHA20POLY1305_NONCE_LENGTH..encrypted_msg.len()];
+    let nonce = XNonce::from_slice(nonce);
+
+    let key = Key::from_slice(key);
+
+    let encrypted_msg = &encrypted_msg[0..encrypted_msg.len()-XCHACHA20POLY1305_NONCE_LENGTH];
+    let aead = XChaCha20Poly1305::new(key);
+
+    aead.decrypt(&nonce, encrypted_msg).ok()
+}

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -6,3 +6,5 @@ pub const AES_TAG_LENGTH: usize = 16;
 pub const AES_IV_PLUS_TAG_LENGTH: usize = AES_IV_LENGTH + AES_TAG_LENGTH;
 /// Empty bytes array
 pub const EMPTY_BYTES: [u8; 0] = [];
+
+pub const XCHACHA20POLY1305_NONCE_LENGTH: usize = 24;

--- a/src/openssl_aes.rs
+++ b/src/openssl_aes.rs
@@ -4,7 +4,7 @@ use rand::{thread_rng, Rng};
 use crate::consts::{AES_IV_LENGTH, AES_IV_PLUS_TAG_LENGTH, AES_TAG_LENGTH, EMPTY_BYTES};
 
 /// AES-256-GCM encryption wrapper
-pub fn aes_encrypt(key: &[u8], msg: &[u8]) -> Option<Vec<u8>> {
+pub fn symmetric_encrypt(key: &[u8], msg: &[u8]) -> Option<Vec<u8>> {
     let cipher = Cipher::aes_256_gcm();
 
     let mut iv = [0u8; AES_IV_LENGTH];
@@ -25,7 +25,7 @@ pub fn aes_encrypt(key: &[u8], msg: &[u8]) -> Option<Vec<u8>> {
 }
 
 /// AES-256-GCM decryption wrapper
-pub fn aes_decrypt(key: &[u8], encrypted_msg: &[u8]) -> Option<Vec<u8>> {
+pub fn symmetric_decrypt(key: &[u8], encrypted_msg: &[u8]) -> Option<Vec<u8>> {
     if encrypted_msg.len() < AES_IV_PLUS_TAG_LENGTH {
         return None;
     }

--- a/src/pure_aes.rs
+++ b/src/pure_aes.rs
@@ -9,7 +9,7 @@ use crate::consts::{AES_IV_LENGTH, AES_IV_PLUS_TAG_LENGTH, EMPTY_BYTES};
 pub type Aes256Gcm = AesGcm<Aes256, U16>;
 
 /// AES-256-GCM encryption wrapper
-pub fn aes_encrypt(key: &[u8], msg: &[u8]) -> Option<Vec<u8>> {
+pub fn symmetric_encrypt(key: &[u8], msg: &[u8]) -> Option<Vec<u8>> {
     let key = GenericArray::from_slice(key);
     let aead = Aes256Gcm::new(key);
 
@@ -33,7 +33,7 @@ pub fn aes_encrypt(key: &[u8], msg: &[u8]) -> Option<Vec<u8>> {
 }
 
 /// AES-256-GCM decryption wrapper
-pub fn aes_decrypt(key: &[u8], encrypted_msg: &[u8]) -> Option<Vec<u8>> {
+pub fn symmetric_decrypt(key: &[u8], encrypted_msg: &[u8]) -> Option<Vec<u8>> {
     if encrypted_msg.len() < AES_IV_PLUS_TAG_LENGTH {
         return None;
     }


### PR DESCRIPTION
This pull request introduces XChaCha20-Poly1305 as a new cryptographic backend for the library. 

The addition of XChaCha20-Poly1305 as a cryptographic backend provides users of this library with more options for their security needs and improves the overall versatility of the library. 

The changes are fully integrated and ready for review. I look forward to any feedback and hope this enhancement will be valuable for the library.
