### PR TITLE
feat: Add zeroize feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,12 @@ aes-12bytes-nonce = ["aes-short-nonce"]
 # xchacha20
 xchacha20 = ["dep:chacha20poly1305"]
 
+# zeroize
+zeroize = [
+  "x25519-dalek/zeroize",
+  "ed25519-dalek/zeroize",
+]
+
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,9 @@ secp256k1 = []
 x25519 = ["dep:curve25519-dalek", "dep:x25519-dalek"]
 ed25519 = ["dep:curve25519-dalek", "dep:ed25519-dalek"]
 
+# zeroize
+zeroize = ["x25519-dalek?/zeroize", "ed25519-dalek?/zeroize"]
+
 # aes
 aes-openssl = ["dep:openssl"]
 aes-rust = ["dep:aes-gcm", "dep:typenum"]
@@ -93,12 +96,6 @@ aes-12bytes-nonce = ["aes-short-nonce"]
 
 # xchacha20
 xchacha20 = ["dep:chacha20poly1305"]
-
-# zeroize
-zeroize = [
-  "x25519-dalek/zeroize",
-  "ed25519-dalek/zeroize",
-]
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ curve25519-dalek = { version = "4.1.3", default-features = false, features = [
 x25519-dalek = { version = "2.0.1", default-features = false, features = [
   "static_secrets",
 ], optional = true }
-ed25519-dalek = { version = "2.1.1", default-features = false, optional = true }
+ed25519-dalek = { version = "~2.1.1", default-features = false, optional = true }
 
 # symmetric ciphers
 # aes (openssl)


### PR DESCRIPTION
Added a new `zeroize` feature that enables the `zeroize` support for both `x25519-dalek` and `ed25519-dalek`. 
Other algorithms already implement zeroize by default .