### PR TITLE
fix(no-std): added spinlock for config checking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,8 @@ wasm-bindgen = { version = "0.2.100", default-features = false }
 once_cell = { version = "1.21.3", default-features = false, features = ["std"] }
 
 [features]
-default = ["aes-openssl", "dep:spin"]
+default = ["aes-openssl", "spin"]
+spin = ["dep:spin"]
 std = ["hkdf/std", "sha2/std", "once_cell/std", "dep:parking_lot"]
 
 # curves

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ once_cell = { version = "1.21.3", default-features = false, features = ["std"] }
 
 [features]
 default = ["aes-openssl", "dep:spin"]
-std = ["hkdf/std", "sha2/std", "once_cell/std"]
+std = ["hkdf/std", "sha2/std", "once_cell/std", "dep:parking_lot"]
 
 # curves
 # no usage, TODO: make optional after 0.3.0: secp256k1 = ["dep:libsecp256k1"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,8 @@ rand_core = { version = "0.6.4", default-features = false, features = [
 once_cell = { version = "1.21.3", default-features = false, features = [
   "critical-section",
 ] }
-parking_lot = "0.12.3"
+parking_lot = { version = "0.12.3", optional = true }
+spin = { version = "0.10.0", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os="unknown"))'.dependencies]
 # only for js (browser or node). if it's not js, like substrate, it won't build
@@ -71,7 +72,7 @@ wasm-bindgen = { version = "0.2.100", default-features = false }
 once_cell = { version = "1.21.3", default-features = false, features = ["std"] }
 
 [features]
-default = ["aes-openssl"]
+default = ["aes-openssl", "dep:spin"]
 std = ["hkdf/std", "sha2/std", "once_cell/std"]
 
 # curves

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,9 @@
 use once_cell::sync::Lazy;
+#[cfg(feature = "std")]
 use parking_lot::RwLock;
+
+#[cfg(not(feature = "std"))]
+use spin::RwLock;
 
 /// ECIES config. Make sure all parties use the same config
 #[derive(Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 #[cfg(feature = "std")]
 use parking_lot::RwLock;
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), feature = "spin"))]
 use spin::RwLock;
 
 /// ECIES config. Make sure all parties use the same config

--- a/src/elliptic/secp256k1.rs
+++ b/src/elliptic/secp256k1.rs
@@ -142,7 +142,7 @@ mod random_tests {
 
     const MSG: &str = "hello world🌍";
     const BIG_MSG_SIZE: usize = 2 * 1024 * 1024; // 2 MB
-    const BIG_MSG: [u8; BIG_MSG_SIZE] = [1u8; BIG_MSG_SIZE];
+    static BIG_MSG: [u8; BIG_MSG_SIZE] = [1u8; BIG_MSG_SIZE];
 
     fn test_enc_dec(sk: &[u8], pk: &[u8]) {
         let msg = MSG.as_bytes();


### PR DESCRIPTION
using ecies-rs in a `no_std` context produced compilation errors complaining about the use of std in `parking_lot`.

The `parking_lot` crate is [_not_ `no_std` compliant](https://docs.rs/parking_lot/latest/src/parking_lot/util.rs.html#8) whereas `lock_api` is, added a spinlock backed `lock_api` compliant `RwLock` for the configuration using the `spin` crate when `std` feature is disabled.